### PR TITLE
LATEX-117: Add support for Content Numbering Extension in LaTeX Export

### DIFF
--- a/latex-syntax/src/main/resources/templates/latex/default/HeaderBlock
+++ b/latex-syntax/src/main/resources/templates/latex/default/HeaderBlock
@@ -1,14 +1,27 @@
 
 
 #set ($headingLevel = $latex.block.getLevel().ordinal() + 1)
+## Test if the numberedheadings script service from the Numbered Headings Application is present, and in this case,
+## check if numbered headings are enabled.
+#if ($services.numberedheadings)
+  #set ($numberedHeadings = $services.numberedheadings.isNumberedHeadingsEnabled())
+#else
+  #set ($numberedHeadings = false)
+#end
 #if ("$!latex.block.getId()" != '')
   \label{${latex.block.getId()}}
 #end
 ## If there's a "data-xwiki-rendering-protected" parameter then the heading must not be numbered. Same if we're already
-## in a protected block
-#if ("$!latex.block.getParameter('data-xwiki-rendering-protected')" != '' || !$latex.tool.getStack('isInProtectedBlock').empty())
+## in a protected block. Headings are also not numbered if a "data-numbered-headings-skip" from the Numbered Headings 
+## Application is defined.
+#if ("$!latex.block.getParameter('data-xwiki-rendering-protected')" != '' || !$latex.tool.getStack('isInProtectedBlock').empty() || "$!latex.block.getParameter('data-numbered-headings-skip')" != '')
   #set ($star = '[*]')
 #else
   #set ($star = '')
+#end
+## When numbered headings is activated and a "data-numbered-headings-start" parameter is found, the "setheadingcounter" 
+## command is called to set the counter of the current heading level to the new value.  
+#if ($numberedHeadings && "$!latex.block.getParameter('data-numbered-headings-start')" != '')
+  \setheadingcounter{$latex.block.getParameter('data-numbered-headings-start')}{$headingLevel}
 #end
 \heading${star}{$headingLevel}{${latex.processor.process($latex.block.getChildren())}}##

--- a/latex-syntax/src/main/resources/templates/latex/default/Preamble
+++ b/latex-syntax/src/main/resources/templates/latex/default/Preamble
@@ -94,6 +94,54 @@ ${SP}${SP}\Gin@nat@width
 #else
   #set ($isBook = false)
 #end
+
+%% Reset the headings counter to a fixed value.
+%% This command takes two parameters. The first one is the new value of the counter.
+%% The second one is the level of the heading to be reset. 
+\newcommand{\setheadingcounter}[2]{
+${SP}${SP}\ifx#21
+#if ($isBook)
+${SP}${SP}${SP}${SP}\setcounter{chapter}{#1}\addtocounter{chapter}{-1}
+#else
+${SP}${SP}${SP}${SP}\setcounter{section}{#1}\addtocounter{section}{-1}
+#end
+${SP}${SP}\else
+${SP}${SP}\ifx#22
+#if ($isBook)
+${SP}${SP}${SP}${SP}\setcounter{section}{#1}\addtocounter{section}{-1}
+#else
+${SP}${SP}${SP}${SP}\setcounter{subsection}{#1}\addtocounter{subsection}{-1}
+#end
+${SP}${SP}\else
+${SP}${SP}\ifx#23
+#if ($isBook)
+${SP}${SP}${SP}${SP}\setcounter{subsection}{#1}\addtocounter{subsection}{-1}
+#else
+${SP}${SP}${SP}${SP}\setcounter{subsubsection}{#1}\addtocounter{subsubsection}{-1}
+#end
+${SP}${SP}\else
+${SP}${SP}\ifx#24
+#if ($isBook)
+${SP}${SP}${SP}${SP}\setcounter{subsubsection}{#1}\addtocounter{subsubsection}{-1}
+#else
+${SP}${SP}${SP}${SP}\setcounter{paragraph}{#1}\addtocounter{paragraph}{-1}
+#end
+${SP}${SP}\else
+${SP}${SP}\ifx#25
+#if ($isBook)
+${SP}${SP}${SP}${SP}\setcounter{paragraph}{#1}\addtocounter{paragraph}{-1}
+#else
+${SP}${SP}${SP}${SP}\setcounter{subparagraph}{#1}\addtocounter{subparagraph}{-1}
+#end
+${SP}${SP}\ifnum#2>5
+${SP}${SP}${SP}${SP}\setcounter{subparagraph}{#1}\addtocounter{subparagraph}{-1}
+${SP}${SP}\fi
+${SP}${SP}\fi
+${SP}${SP}\fi
+${SP}${SP}\fi
+${SP}${SP}\fi
+${SP}${SP}\fi}
+
 \newcommand{\heading}[3][]{
 ${SP}${SP}\ifx#21
 ${SP}${SP}${SP}${SP}#if ($isBook)\chapter#1\{#3}#else\section#1{#3}#end

--- a/latex-syntax/src/test/resources/latex10/specific/misc/preamble.test
+++ b/latex-syntax/src/test/resources/latex10/specific/misc/preamble.test
@@ -85,6 +85,34 @@
 \makeatother
 
 %% Define heading command so that it can be overridden easily
+
+%% Reset the headings counter to a fixed value.
+%% This command takes two parameters. The first one is the new value of the counter.
+%% The second one is the level of the heading to be reset. 
+\newcommand{\setheadingcounter}[2]{
+  \ifx#21
+    \setcounter{section}{#1}\addtocounter{section}{-1}
+  \else
+  \ifx#22
+    \setcounter{subsection}{#1}\addtocounter{subsection}{-1}
+  \else
+  \ifx#23
+    \setcounter{subsubsection}{#1}\addtocounter{subsubsection}{-1}
+  \else
+  \ifx#24
+    \setcounter{paragraph}{#1}\addtocounter{paragraph}{-1}
+  \else
+  \ifx#25
+    \setcounter{subparagraph}{#1}\addtocounter{subparagraph}{-1}
+  \ifnum#2>5
+    \setcounter{subparagraph}{#1}\addtocounter{subparagraph}{-1}
+  \fi
+  \fi
+  \fi
+  \fi
+  \fi
+  \fi}
+
 \newcommand{\heading}[3][]{
   \ifx#21
     \section#1{#3}


### PR DESCRIPTION
- Introduce the setheadingcounter latex command to reset the headings counter to a new value in the Preamble template
- Update the HeaderBlock template to take into account numbered content specific configurations and parameters